### PR TITLE
Update docker to add support for gunicorn for higher intensity scans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Mac OS X
+.DS_Store
+
+# Python
+venv
+
+# Python distribution/packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+__pycache__/
+**/__pycache__/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,18 @@ MAINTAINER jsvazic@gmail.com
 FROM python:3.7
 
 COPY . /app/
+WORKDIR /app
 
 RUN pip install --upgrade pip && \
     pip3 install -r /app/requirements.txt
 
+RUN python3 /app/Tiredful_API/manage.py collectstatic --noinput
+
 WORKDIR /app/Tiredful_API/
+
+ENV GUNICORN_WORKER_COUNT=4
+ENV GUNICORN_WORKER_TIMEOUT_SEC=60
 
 EXPOSE 8000
 
-CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD gunicorn --bind 0.0.0.0:8000 Tiredful_API.wsgi --workers=$GUNICORN_WORKER_COUNT --timeout=$GUNICORN_WORKER_TIMEOUT_SEC --log-level=debug

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ docker run -p 8000:8000 --name tiredful -it tiredful
 
 Browse to `http://localhost:8000/` and you are all set.  Use `CTRL-C` to shut down the server.
 
+#### Docker Compose
+
+You can also spin up Tiredful API using Docker Compose.  Simply execute:
+
+```bash
+docker compose -f docker-compose-dev.yml up
+```
+
+The application files will refresh automatically when you make changes to the source code.  Use `CTRL-C` to shut down the server.
+
+If you want to run the application without refreshing the application files, execute:
+
+```bash
+docker-compose up -d
+```
+
 #### Python3 Compatible Code
 [Tiredful API Python3](https://github.com/siddharthbezalwar/Tiredful-API-py3-beta)
 

--- a/Tiredful_API/Tiredful_API/settings.py
+++ b/Tiredful_API/Tiredful_API/settings.py
@@ -143,6 +143,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')  # Ensure this is different from STATICFILES_DIRS
 
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),

--- a/Tiredful_API/Tiredful_API/urls.py
+++ b/Tiredful_API/Tiredful_API/urls.py
@@ -23,6 +23,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, include
 
@@ -64,3 +66,6 @@ urlpatterns = [
     path('jwt-token/', include(('broken_token.urls', 'broken_token'), namespace="broken-token")),
 
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/Tiredful_API/templates/elements/css-content.html
+++ b/Tiredful_API/templates/elements/css-content.html
@@ -8,7 +8,8 @@
 
  This file is part of Tiredful API application -->
 
+{% load static %}
 <!-- Bootstrap core CSS -->
-<link href="{{ STATIC_URL }}css/bootstrap.min.css" rel="stylesheet">
+<link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
 <!-- Bootstrap theme -->
-<link href="{{ STATIC_URL }}css/bootstrap-theme.css" rel="stylesheet">
+<link href="{% static 'css/bootstrap-theme.css' %}" rel="stylesheet">

--- a/Tiredful_API/templates/elements/javascript-content.html
+++ b/Tiredful_API/templates/elements/javascript-content.html
@@ -9,10 +9,10 @@
 
  This file is part of Tiredful API application -->
 
-
+{% load static %}
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="{{ STATIC_URL }}/js/vendor/jquery.min.js"><\/script>')</script>
-<script src="{{ STATIC_URL }}/js/bootstrap.min.js"></script>
+<script>window.jQuery || document.write('<script src="{% static '/js/vendor/jquery.min.js' %}"><\/script>')</script>
+<script src="{% static '/js/bootstrap.min.js' %}"></script>
 <script>
 $(document).ready(function() {
 	// get current URL path and assign 'active' class

--- a/Tiredful_API/wsgi.py
+++ b/Tiredful_API/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for nimbler_django project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/4.1/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "Tiredful_API.settings")
+
+application = get_wsgi_application()

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,10 @@
+services:
+  tiredful-api:
+    container_name: tiredful-api
+    build:
+      context: .
+    volumes:
+      - .:/app
+      - ./Tiredful_API/static:/app/Tiredful_API/staticfiles
+    ports:
+      - 8000:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  tiredful-api:
+    container_name: tiredful-api
+    build:
+      context: .
+    ports:
+      - 8000:8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ cryptography==3.4.7
 Django==3.2
 django-oauth-toolkit==1.5.0
 djangorestframework==3.12.4
+gunicorn==22.0.0
 idna==2.10
 jwcrypto==0.8
 oauthlib==3.1.0


### PR DESCRIPTION
Hi, thanks for building this application! I was using it to build some benchmark scans. I wanted it to be able to handle higher intensity scans, which wasn't possible when it was running using `manage.py runserver`. I made some modifications to add gunicorn support which will allow for multithreaded scans. 

I realize there are 11 changed files as part of this PR, none of which have tests, and that you are probably very busy. So I made a Loom video to show you how it has backwards compatibility with the previous setup, in case you want to merge this as a PR. https://www.loom.com/share/41c38f39c6dd4db4b8ac7bcb52d6d325. I also managed to get the static files working in docker as well.

Hope this helps! Thanks.